### PR TITLE
Change module name to github.com/canonical/go-flags

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/jessevdk/go-flags"
+	"github.com/canonical/go-flags"
 	"os"
 	"strconv"
 	"strings"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jessevdk/go-flags
+module github.com/canonical/go-flags
 
 go 1.15
 


### PR DESCRIPTION
Make this a proper fork.

Note that this commit doesn't change links to 3rd party CI services in
the README.md, which still point to github.com/jessevdk/go-flags module.